### PR TITLE
Remove Categories

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -8,9 +8,6 @@ const blog = defineCollection({
     description: z.string().optional(),
     date: z.coerce.date(),
     tags: z.array(z.string()).optional().default([]),
-    categories: z.union([z.string(), z.array(z.string())]).transform(val =>
-      Array.isArray(val) ? val : [val]
-    ).optional().default(['uncategorized']),
     image: z.union([
       z.string(),
       z.object({

--- a/src/content/blog/a-mais-bela-formula-da-matematica-parte-I.mdx
+++ b/src/content/blog/a-mais-bela-formula-da-matematica-parte-I.mdx
@@ -3,7 +3,6 @@ title: "A mais bela fórmula da Matemática (Parte I)"
 description: "Notas sobre um seminário"
 date: 2015-11-03 18:00:00
 tags: [math, portuguese]
-categories: math
 ---
 
 import YouTubeEmbed from "../../components/YouTubeEmbed.astro";

--- a/src/content/blog/dual-boot-ubuntu-windows-msi-ge72-2qe.md
+++ b/src/content/blog/dual-boot-ubuntu-windows-msi-ge72-2qe.md
@@ -3,7 +3,6 @@ title:  "Dual boot on a SSD"
 description: "Some steps to install Ubuntu alongside Windows 8.1 on an MSI GE72 2QE laptop with an HDD + SSD setup."
 date:   2015-10-30 12:00:00
 tags: [linux, ubuntu, windows, msi, ge72, 2qe, ssd, uefi]
-categories: programming
 ---
 
 My old LG laptop was unusable for my work. Random shutdowns and overheating were

--- a/src/content/blog/fix-ipython-missing-files-problem.md
+++ b/src/content/blog/fix-ipython-missing-files-problem.md
@@ -3,7 +3,6 @@ title:  "A quick fix for some IPython notebook IOErrors"
 description: "It says some files are missing, like a custom.js."
 date:   2015-09-04 16:00:00
 tags: [linux, ubuntu, python, ipython, notebook]
-categories: programming
 ---
 
 I had a working version of IPython running on Ubuntu 14.04, but today I found an

--- a/src/content/blog/i-did-a-rm-r-bin.md
+++ b/src/content/blog/i-did-a-rm-r-bin.md
@@ -3,7 +3,6 @@ title:  "I did a rm -r /bin!"
 description: "How I used Docker to bring back some of my binaries."
 date:   2015-04-08 20:00:00
 tags: [linux, docker, ubuntu]
-categories: programming
 ---
 
 I just did something really stupid:

--- a/src/content/blog/installing-some-r-packages.md
+++ b/src/content/blog/installing-some-r-packages.md
@@ -3,7 +3,6 @@ title:  "Installing some R packages"
 description: "Quick troubleshooting installing xlsx and XML packages on Debian Wheezy"
 date:   2014-08-10 16:15:00
 tags: [r, coursera]
-categories: programming
 ---
 
 I'm doing Coursera's [Specialization in Data Science] and right now I'm in the third course of it, called Getting and Cleaning Data.

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from './BaseLayout.astro';
 const { post } = Astro.props;
-const { title, date, categories, image } = post.data;
+const { title, date, tags, image } = post.data;
 const featureImage = typeof image === 'string' ? image : image?.feature;
 ---
 <BaseLayout title={title} description={post.data.description}>
@@ -19,8 +19,12 @@ const featureImage = typeof image === 'string' ? image : image?.feature;
         <time datetime={date.toISOString()}>
           {date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
         </time>
-        {categories && categories.length > 0 && (
-          <span class="capitalize">{categories[0]}</span>
+        {tags && tags.length > 0 && (
+          <div class="flex gap-2">
+            {tags.map((tag: string) => (
+              <span class="capitalize bg-zinc-100 dark:bg-zinc-800 px-2 py-0.5 rounded-md text-xs">{tag}</span>
+            ))}
+          </div>
         )}
       </div>
     </header>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -22,7 +22,7 @@ const featureImage = typeof image === 'string' ? image : image?.feature;
         {tags && tags.length > 0 && (
           <div class="flex gap-2">
             {tags.map((tag: string) => (
-              <span class="capitalize bg-zinc-100 dark:bg-zinc-800 px-2 py-0.5 rounded-md text-xs">{tag}</span>
+              <a href={`/blog/tags/${tag}`} class="capitalize bg-zinc-100 hover:bg-zinc-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 px-2 py-0.5 rounded-md text-xs transition-colors">{tag}</a>
             ))}
           </div>
         )}

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -22,6 +22,13 @@ const sortedPosts = posts.sort((a, b) => b.data.date.getTime() - a.data.date.get
           {post.data.description && (
             <p class="mt-2 text-zinc-600 dark:text-zinc-400 line-clamp-2">{post.data.description}</p>
           )}
+          {post.data.tags && post.data.tags.length > 0 && (
+            <div class="flex gap-2 mt-3">
+              {post.data.tags.map((tag: string) => (
+                <a href={`/blog/tags/${tag}`} class="capitalize bg-zinc-100 hover:bg-zinc-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 px-2 py-0.5 rounded-md text-xs transition-colors">{tag}</a>
+              ))}
+            </div>
+          )}
         </article>
       ))}
     </div>

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -1,0 +1,49 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import { getPostPath } from '../../../utils/blog';
+
+export async function getStaticPaths() {
+  const allPosts = await getCollection('blog');
+  const uniqueTags = [...new Set(allPosts.map((post) => post.data.tags).flat())];
+
+  return uniqueTags.map((tag) => {
+    const filteredPosts = allPosts.filter((post) => post.data.tags.includes(tag));
+    return {
+      params: { tag },
+      props: { posts: filteredPosts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime()) },
+    };
+  });
+}
+
+const { tag } = Astro.params;
+const { posts } = Astro.props;
+---
+
+<BaseLayout title={`Tag: ${tag}`} description={`Posts tagged with ${tag}`}>
+  <div class="max-w-3xl mx-auto px-4 py-16">
+    <h1 class="text-3xl font-bold mb-12 tracking-tight">Tag: <span class="capitalize">{tag}</span></h1>
+    <div class="space-y-12">
+      {posts.map((post: any) => (
+        <article class="group">
+          <time datetime={post.data.date.toISOString()} class="text-sm text-zinc-500 dark:text-zinc-500 mb-2 block">
+            {post.data.date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+          </time>
+          <h2 class="text-xl font-semibold group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+            <a href={getPostPath(post)}>{post.data.title}</a>
+          </h2>
+          {post.data.description && (
+            <p class="mt-2 text-zinc-600 dark:text-zinc-400 line-clamp-2">{post.data.description}</p>
+          )}
+          {post.data.tags && post.data.tags.length > 0 && (
+            <div class="flex gap-2 mt-3">
+              {post.data.tags.map((t: string) => (
+                <a href={`/blog/tags/${t}`} class="capitalize bg-zinc-100 hover:bg-zinc-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 px-2 py-0.5 rounded-md text-xs transition-colors">{t}</a>
+              ))}
+            </div>
+          )}
+        </article>
+      ))}
+    </div>
+  </div>
+</BaseLayout>

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -1,14 +1,5 @@
-export function getPostPath(post: { id: string, data: { categories?: any, category?: string } }) {
+export function getPostPath(post: { id: string }) {
   const slug = post.id.replace(/^\d{4}-\d{2}-\d{2}-/, '').replace(/\.[^/.]+$/, '');
 
-  let category = 'uncategorized';
-  if (Array.isArray(post.data.categories) && post.data.categories.length > 0) {
-    category = post.data.categories[0];
-  } else if (typeof post.data.categories === 'string') {
-    category = post.data.categories;
-  } else if (post.data.category) {
-    category = post.data.category;
-  }
-
-  return `/blog/${category}/${slug}`;
+  return `/blog/${slug}`;
 }


### PR DESCRIPTION
Removed `categories` from blog collection schema, URL generation logic (`src/utils/blog.ts`), layout rendering (`src/layouts/PostLayout.astro`), and all blog posts frontmatter. The categorization will now rely solely on tags.

---
*PR created automatically by Jules for task [13946791321626144543](https://jules.google.com/task/13946791321626144543) started by @allanino*