### PR TITLE
🔒 Fix reverse tabnabbing vulnerability in project links

### DIFF
--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -52,7 +52,7 @@ const projects = [
         <div class="border border-zinc-200 dark:border-zinc-800 rounded-lg p-6 hover:border-blue-500 transition-colors">
           <h2 class="text-xl font-bold mb-2">{project.title}</h2>
           <p class="text-zinc-600 dark:text-zinc-400 mb-4">{project.description}</p>
-          <a href={project.link} target="_blank" class="text-blue-600 hover:underline font-medium">View on GitHub →</a>
+          <a href={project.link} target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline font-medium">View on GitHub →</a>
         </div>
       ))}
     </div>


### PR DESCRIPTION
🎯 **What:** Fixed a reverse tabnabbing vulnerability in `src/pages/projects.astro`.
⚠️ **Risk:** Links with `target="_blank"` without `rel="noopener noreferrer"` can allow the newly opened page to control the original page via the `window.opener` API, potentially leading to phishing attacks.
🛡️ **Solution:** Added the `rel="noopener noreferrer"` attribute to the external link to prevent the new tab from accessing the original window object.

---
*PR created automatically by Jules for task [13098132630455862079](https://jules.google.com/task/13098132630455862079) started by @allanino*